### PR TITLE
docs + chore: README rewrite and Claude Code automations

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,5 +6,29 @@
       "Bash(python3 -m pip install:*)",
       "Bash(python3:*)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const f = process.env.CLAUDE_TOOL_INPUT_FILE_PATH || ''; if (f.includes('overlay-')) { console.error('[DEMO GUARD] Editing a live OBS overlay file: ' + f + '. Verify this will not break the demo before proceeding.'); process.exit(1); }\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node -e \"const f = process.env.CLAUDE_TOOL_INPUT_FILE_PATH || ''; if (f.includes('server.js') || f.includes('socket.js')) { console.log('[PORT WATCH] Port-sensitive file edited: ' + f.split(/[\\\\/]/).pop() + '. Consider running port-consistency-checker if the IP or port changed.'); }\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,15 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
+      }
+    },
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Rewrites README with accurate project structure, IP config callout, working API curl examples, overlay detail tables, debugging guide, and a tight 30-second demo script
- Adds `.mcp.json` with GitHub MCP and context7 for live docs

## Changes

### README.md
- Fixes project structure (was missing `control-panel/`, `overlay-dice.html`, Svelte components)
- Adds IP configuration callout — most common setup failure
- Accurate API docs with working `curl` examples
- Overlay detail tables (HP thresholds, dice crit/fail)
- Debugging symptom-to-fix table
- Honest roadmap: Day 2 done, Day 3 remaining
- Removes duplicate headings and copy-paste artifacts

### .mcp.json
- GitHub MCP via `GITHUB_PERSONAL_ACCESS_TOKEN` env var
- context7 for live Express 5 / Socket.io 4 / Svelte 5 docs

## Test plan
- [ ] Follow Quick Start from scratch and verify all steps work
- [ ] Confirm IP config section matches `server.js` and `socket.js`
- [ ] Verify `.mcp.json` loads in Claude Code (`claude mcp list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)