### PR TITLE
feat: GitHub <-> Notion <-> AI integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,80 +1,83 @@
 # Copilot instructions
 
+Real-time D&D streaming overlay for DADOS & RISAS. **Stack:** Bun + Express + Socket.io · Svelte 5 / SvelteKit · PocketBase.
+
 ## Quick index
 
-- See `docs/INDEX.md` for the fast file map, entry points, and do-not-edit paths.
-- See `docs/ARCHITECTURE.md` for data-flow diagrams and full file map.
-- See `docs/SOCKET-EVENTS.md` for complete Socket.io event payloads.
-- See `docs/DESIGN-SYSTEM.md` for CSS tokens, component states, and animation reference.
+- `SPRINT.md` — current sprint tasks (auto-generated, always up to date)
+- `docs/INDEX.md` — fast file map, entry points, do-not-edit paths
+- `docs/ARCHITECTURE.md` — data-flow diagrams and full file map
+- `docs/SOCKET-EVENTS.md` — complete Socket.io event payloads
+- `docs/DESIGN-SYSTEM.md` — CSS tokens, component states, animation reference
 
 ## Build, test, and lint commands
 
-- **Root backend** (Node.js/Express/Socket.io):
-  - `npm install`
-  - `npm run setup-ip` — auto-detects local IP and generates root `.env` + `control-panel/.env`.
-  - `node server.js` — starts Express + Socket.io on `PORT` (default 3000).
-  - No automated tests on the backend; use `test.http` at the root or `curl http://localhost:3000/api/characters` for manual verification.
+- **Start order:** PocketBase first (`./pocketbase serve`), then `bun server.js`, then control panel.
+- **Root backend:** `bun server.js` — Express + Socket.io on port 3000. Auto-seeds PocketBase on first boot.
+- **IP setup:** `bun run setup-ip` — detects LAN IP, writes root `.env` + `control-panel/.env`.
 - **Control panel** (`cd control-panel` first):
-  - `npm run dev -- --host` — Vite dev server with LAN exposure for phone access.
-  - `npm run dev:auto` — runs `setup-ip` + `vite dev --host` in one step.
-  - `npm run build` / `npm run preview` — production build.
-  - `npm run lint` — ESLint (eslint-plugin-svelte + eslint v9 flat config).
-  - `npm test` — Vitest (runs all unit tests).
-  - `npx vitest run path/to/file.test.js` — run a single test file.
-  - `npm run storybook` — Storybook dev server on port 6006.
-- **Design tokens**: `bun run generate:tokens` (at repo root) — regenerates `control-panel/src/generated-tokens.css` and `public/tokens.css` from `design/tokens.json`. Always run after editing tokens.
-- **Playwright E2E**: `npx playwright test app.test.js --config tests-log/playwright.config.js` (logs saved under `tests-log/`).
+  - `bun run dev -- --host` — Vite dev server with LAN exposure (port 5173)
+  - `bun run build` / `bun run preview` — production build
+  - `bun run lint` — ESLint (eslint-plugin-svelte, flat config v9)
+  - `bun run test` — Vitest unit tests
+  - `bun run storybook` — Storybook dev server (port 6006)
+- **Design tokens:** `bun run generate:tokens` at repo root — regenerates CSS from `design/tokens.json`. Always run after editing tokens.
+- **Playwright E2E:** `bunx playwright test app.test.js --config tests-log/playwright.config.js`
 
-## High-level architecture
+## Architecture
 
 ```
 Phone / Tablet
-  └── control-panel (SvelteKit + Vite, port 5173) – Socket.io client + REST calls for HP/rolls, mobile-first UI, reuses a singleton socket store.
+  └── control-panel (SvelteKit + Vite, :5173) — REST + Socket.io client
         │
-        │  HTTP PUT /api/characters/:id/hp  (CharacterCard)  &  POST /api/rolls (DiceRoller)
         ▼
-  Node.js server (Express + Socket.io, port 3000)
-        │
-        │  REST API + `io.emit` broadcasts (`initialData`, `hp_updated`, `dice_rolled`)
+  Bun server (Express + Socket.io, :3000)
+  [data/characters.js] [data/rolls.js]  ← PocketBase SDK wrappers
+        │  io.emit broadcasts to ALL clients
         ▼
-  `public/overlay-hp.html` + `public/overlay-dice.html` (OBS Browser Sources, load Socket.io via CDN and listen for `hp_updated` / `dice_rolled` to mutate DOM by `data-char-id` attributes)
+  PocketBase (:8090, SQLite)
+        ▼
+  SvelteKit overlay routes (served at :5173)
+  /persistent/hp  /persistent/conditions  /moments/dice  /announcements  …
+  (OBS Browser Sources — Svelte 5, listen-only via Socket.io)
 ```
-
-- The server keeps `characters` and `rolls` in-memory and seeds each socket with `initialData` on connect; every REST update broadcasts via Socket.io so overlays and the control panel stay in sync.
-- The `control-panel/src/lib/socket.js` file exports the singleton `socket`, `characters` store, and `lastRoll` store so every component shares the same connection and state.
-- Overlays rely on the same `serverPort` host (and Socket.io v4.8.3 via CDN) and mutate DOM nodes marked with `data-char-id` to reflect live HP/roll updates.
 
 ## SvelteKit routing
 
-- File-based routes live in `control-panel/src/routes`.
-- Redirect: `src/routes/+page.svelte` routes `/` to `/control/characters`.
-- Layout shell: `src/routes/+layout.svelte` provides the app chrome (header/sidebar).
-- Control tabs: `src/routes/control/+layout.svelte` + pages at `/control/characters` and `/control/dice`.
-- Management tabs: `src/routes/management/+layout.svelte` + pages at `/management/create` and `/management/manage`.
+Route groups use `(parens)` — organizational only, not part of URLs.
+
+- `(stage)/live/characters` — HP, conditions, resources management
+- `(stage)/live/dice` — dice roller
+- `(stage)/setup/create` — character creation
+- `(stage)/setup/manage` — photo/data editing
+- `(stage)/overview` — live read-only operator dashboard
+- `(cast)/dm` — initiative tracker + Session Panel
+- `(cast)/players/[id]` — player character sheet
+- `(audience)/persistent/hp` — HP overlay (OBS)
+- `(audience)/persistent/conditions` — conditions overlay (OBS)
+- `(audience)/moments/dice` — dice roll moment (OBS)
+- `(audience)/announcements` — announcement overlay (OBS)
 
 ## Key conventions
 
-- **IP alignment**: use `npm run setup-ip` to generate root `.env` and `control-panel/.env`. Overlays read the server URL from the `?server=` query parameter (default `http://localhost:3000`).
-- **Socket flow**: `socket.on('initialData')` bootstraps the `characters` store. Components always send a REST request first, then rely on the resulting Socket.io broadcast to update shared state — never mutate stores directly from component logic.
-- **DOM mapping**: Overlays use `data-char-id` attributes to locate nodes in the DOM. When `hp_updated` arrives, only the matching node is mutated. Keep `data-char-id` populated if adding new overlays.
-- **Svelte 5 runes**: The control panel uses Svelte 5 runes (`$state`, `$derived`, `$effect`) throughout — not the legacy `writable`/`readable` store API inside components. The global `characters` and `lastRoll` stores in `socket.js` remain Svelte writable stores because they are shared singletons.
-- **CSS architecture**: Each Svelte component has a paired `.css` file (e.g. `CharacterCard.svelte` + `CharacterCard.css`). Shared base classes (`.card-base`, `.btn-base`, `.label-caps`) live in `app.css` — extend them instead of re-implementing. Design tokens are defined in `design/tokens.json` and generated into `control-panel/src/generated-tokens.css` and `public/tokens.css`; never edit the generated files directly.
-- **State modifier naming**: BEM-style `is-` prefix for all boolean state classes (`.is-critical`, `.is-selected`, `.is-crit`, `.is-fail`). The outlier `.collapsed` on `.char-card` is a known issue; use `.is-collapsed` on new work.
-- **UI component library**: The control panel uses `bits-ui` v2 (headless primitives) + `tailwind-variants` for variant styling. shadcn/svelte aliases are set up in `app.css`.
-- **Animations**: Use `anime.js` (already imported via the `animejs` package) for programmatic animations (damage flash, dice bounce). CSS transitions handle HP bar width and collapse height.
-- **Manual testing helpers**: Use `test.http` at the root for quick `GET /api/characters`, `PUT /api/characters/:id/hp`, and `POST /api/rolls` requests with pre-filled demo payloads.
+- **Runtime:** Use `bun` everywhere — `bun install`, `bun server.js`, `bun run dev`.
+- **PocketBase:** All `data/` functions take `pb` as first arg and are `async`. `getOne()` throws on 404 — use try/catch.
+- **Socket flow:** Components send REST first; Socket.io broadcast updates shared state. Never mutate stores directly.
+- **Svelte 5 runes:** Use ``, ``, `` in components. Global `characters` / `lastRoll` in `socket.js` stay as writable stores (shared singletons).
+- **CSS:** Each component has a paired `.css` file. State classes use `is-` prefix. Token variables from `generated-tokens.css` via `var(--token-name)`.
+- **UI library:** `bits-ui` v2 (headless primitives) + `tailwind-variants`. Shared base classes (`.card-base`, `.btn-base`, `.label-caps`) in `app.css`.
+- **Animations:** `anime.js` for programmatic effects; CSS transitions for HP bar / collapse.
+- **Storybook:** Run `bun run storybook` in `control-panel/` before any UI work — component context at `http://localhost:6006`.
+- **Servers:** Always stop servers (Ctrl+C) before finishing a task.
 
-## Server handling
+## When you find a bug or improvement
 
-- **Running servers**: Start the Node.js server first (`node server.js`), then run the Svelte control panel on ./control-panel (`npm run dev -- --host`).
-- **Closing Servers**: After running server instances remember to always close them properly (Ctrl+C in terminal) to free up ports and avoid conflicts on next run.
-- **Agent reminder**: If you start a server during a task, stop it before you finish the response. This is mandatory for all agents.
+Open a GitHub Issue — Notion syncs automatically.
 
-## UI development
+**Area:** `area:frontend` (Svelte, CSS, overlays) · `area:backend` (server.js, API, Socket.io, PocketBase)
+**Priority:** `p0` blocking · `p1` this sprint · `p2` next · `p3` someday
+**Size:** `size:quick` <1hr · `size:small` 1–3hr · `size:medium` 3–8hr · `size:large` 8+hr
 
-Before doing any UI or frontend work, call the Storybook MCP server to get component context and story URLs. Storybook runs at `http://localhost:6006` (`cd control-panel && npm run storybook`).
+Assign to current milestone: **Sprint 1 — Bug Fix & Stability**
 
-## Additional references
-
-- The README and CLAUDE.md describe the demo priorities, OBS setup (1920×1080, transparent backgrounds, “refresh when scene becomes active”), and the project’s MVP checklist. Refer to them before updating the overlays or control panel UI.
-- The `.github/workflows/check-progress.yml` job parses `PROGRESS.md` on every push; keep that file’s sections intact if you need the progress reporting to stay green.
+For non-tech items (outreach, session planning) → add directly to Notion, not GitHub.

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -1,0 +1,49 @@
+name: Sync Issues to Notion
+
+on:
+  issues:
+    types:
+      - labeled  # create Notion task when area label applied
+      - closed   # mark Notion task as Done
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      # ── CREATE: area label applied ──────────────────────────────────────────
+      - name: Create Notion task
+        if: |
+          github.event.action == 'labeled' &&
+          (github.event.label.name == 'area:frontend' ||
+           github.event.label.name == 'area:backend')
+        env:
+          NOTION_API_TOKEN: ${{ secrets.NOTION_API_TOKEN }}
+          OPERATION:        create
+          ISSUE_NUMBER:     ${{ github.event.issue.number }}
+          ISSUE_TITLE:      ${{ github.event.issue.title }}
+          AREA_LABEL:       ${{ github.event.label.name }}
+          PRIORITY_LABEL:   ${{ join(github.event.issue.labels.*.name, ' ') }}
+          SIZE_LABEL:       ${{ join(github.event.issue.labels.*.name, ' ') }}
+          MILESTONE_TITLE:  ${{ github.event.issue.milestone.title }}
+        run: |
+          PRIORITY=$(echo "$PRIORITY_LABEL" | tr ' ' '\n' | grep -E '^p[0-3]$' | head -1)
+          SIZE=$(echo "$SIZE_LABEL" | tr ' ' '\n' | grep -E '^size:' | head -1)
+          PRIORITY_LABEL=$PRIORITY SIZE_LABEL=$SIZE node scripts/notion-sync.mjs
+
+      # ── CLOSE: issue closed → Notion task Done ──────────────────────────────
+      - name: Close Notion task
+        if: github.event.action == 'closed'
+        env:
+          NOTION_API_TOKEN: ${{ secrets.NOTION_API_TOKEN }}
+          OPERATION:        close
+          ISSUE_NUMBER:     ${{ github.event.issue.number }}
+        run: node scripts/notion-sync.mjs

--- a/.github/workflows/sprint-file.yml
+++ b/.github/workflows/sprint-file.yml
@@ -1,0 +1,44 @@
+name: Regenerate SPRINT.md
+
+on:
+  issues:
+    types:
+      - opened
+      - closed
+      - labeled
+      - unlabeled
+      - milestoned
+      - demilestoned
+  workflow_dispatch: # allow manual trigger
+
+permissions:
+  contents: write
+  issues: read
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Generate SPRINT.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: node scripts/generate-sprint.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add SPRINT.md
+          git diff --staged --quiet || git commit -m "chore: update SPRINT.md [skip ci]"
+          git push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,3 +166,57 @@ Before doing any UI or frontend work, check Storybook for component context and 
 - `docs/ENVIRONMENT.md` — `.env` setup, IP configuration
 - `docs/THEMING.md` — token generator usage and live theme editor
 - `docs/INDEX.md` — fast file map and entry points
+
+---
+
+## Agent Rules — How to Update the Planner
+
+### After any audit, investigation, or review:
+
+**For tech findings (bugs, improvements, refactors):**
+
+1. Create a GitHub Issue at: https://github.com/s0lci700/OVERLAYS/issues/new
+2. Apply the correct labels:
+   - Area: `area:frontend` ← Svelte components, CSS, HTML overlays, design tokens
+   - Area: `area:backend` ← server.js, API routes, Socket.io events, data modules, PocketBase
+   - Priority: `p0` (blocking) / `p1` (this sprint) / `p2` (next sprint) / `p3` (someday)
+   - Size: `size:quick` (<1hr) / `size:small` (1–3hr) / `size:medium` (3–8hr) / `size:large` (8+hr)
+3. Assign to the correct Milestone (Sprint 1, 2, or 3)
+4. Notion task is created automatically when the area label is applied.
+
+**For non-tech findings (outreach, session planning, content):**
+
+Add directly to Notion: https://notion.so/319b63b6f5ec81bcbe9aeb2b6815c88c
+- Area: `📣 Pitch & Outreach` or `🎭 Session Planning`
+- These never become GitHub Issues.
+
+### Current sprint
+
+See `SPRINT.md` for active tasks. It is always current — do not query Notion directly.
+
+### Routing cheat-sheet
+
+| Type of finding | Where it goes |
+|-----------------|---------------|
+| Svelte component bug | GitHub Issue, `area:frontend` |
+| CSS / overlay visual fix | GitHub Issue, `area:frontend` |
+| API endpoint bug | GitHub Issue, `area:backend` |
+| Socket.io event issue | GitHub Issue, `area:backend` |
+| PocketBase / data layer issue | GitHub Issue, `area:backend` |
+| Contact ESDH / follow up | Notion task, Pitch & Outreach |
+| Campaign planning with Lucas | Notion task, Session Planning |
+
+### Label → Notion field mapping
+
+| GitHub Label | Notion Field | Value |
+|---|---|---|
+| `area:frontend` | Area | 🎨 Frontend |
+| `area:backend` | Area | ⚙️ Backend |
+| `p0` | Priority | P0 — Now |
+| `p1` | Priority | P1 — Soon |
+| `p2` | Priority | P2 — Later |
+| `p3` | Priority | P3 — Someday |
+| `size:quick` | Size | Quick |
+| `size:small` | Size | Small |
+| `size:medium` | Size | Medium |
+| `size:large` | Size | Large |

--- a/scripts/generate-sprint.mjs
+++ b/scripts/generate-sprint.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// generate-sprint.mjs
+// Generates SPRINT.md from the active GitHub Milestone.
+// Called by .github/workflows/sprint-file.yml
+// Usage: GITHUB_TOKEN=xxx REPO=s0lci700/OVERLAYS node scripts/generate-sprint.mjs
+
+import { execSync } from "child_process";
+import { writeFileSync } from "fs";
+
+const REPO = process.env.REPO || "s0lci700/OVERLAYS";
+const TOKEN = process.env.GITHUB_TOKEN;
+
+function gh(endpoint) {
+  const result = execSync(`gh api "${endpoint}" --paginate`, {
+    env: { ...process.env, GH_TOKEN: TOKEN },
+    encoding: "utf8",
+  });
+  return JSON.parse(result);
+}
+
+// Get the earliest open milestone (= current sprint)
+const milestones = gh(
+  `repos/${REPO}/milestones?state=open&sort=created&direction=asc`
+);
+if (milestones.length === 0) {
+  console.log("No open milestones found. Writing empty SPRINT.md.");
+  writeFileSync("SPRINT.md", "# No active sprint\n");
+  process.exit(0);
+}
+
+const milestone = milestones[0];
+console.log(`Active milestone: ${milestone.title} (#${milestone.number})`);
+
+// Get all open issues in this milestone
+const openIssues = gh(
+  `repos/${REPO}/issues?milestone=${milestone.number}&state=open&per_page=100`
+);
+
+// Get recently closed issues (last 7 days) for the Done section
+const since = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+const closedIssues = gh(
+  `repos/${REPO}/issues?milestone=${milestone.number}&state=closed&since=${since}&per_page=50`
+);
+
+function getLabel(issue, prefix) {
+  const match = issue.labels.find((l) => l.name.startsWith(prefix));
+  return match ? match.name : null;
+}
+
+function formatIssue(issue) {
+  const priority = getLabel(issue, "p") ?? "?";
+  const size = getLabel(issue, "size:") ?? "?";
+  return `- [ ] #${issue.number} ${issue.title} [${priority}, ${size}]`;
+}
+
+function formatClosedIssue(issue) {
+  const priority = getLabel(issue, "p") ?? "?";
+  return `- [x] #${issue.number} ${issue.title} [${priority}]`;
+}
+
+const frontend = openIssues.filter(
+  (i) => getLabel(i, "area:") === "area:frontend"
+);
+const backend = openIssues.filter(
+  (i) => getLabel(i, "area:") === "area:backend"
+);
+const other = openIssues.filter((i) => !getLabel(i, "area:"));
+
+const now =
+  new Date().toISOString().replace("T", " ").slice(0, 16) + " UTC";
+const openCount = openIssues.length;
+const closedCount = closedIssues.length;
+
+const lines = [
+  `# Active Sprint: ${milestone.title}`,
+  ``,
+  `> Auto-generated from GitHub Issues. Do not edit manually.`,
+  `> ${openCount} open · ${closedCount} closed this week · Last updated: ${now}`,
+  ``,
+];
+
+if (frontend.length > 0) {
+  lines.push(`## 🎨 Frontend`, ``);
+  frontend.forEach((i) => lines.push(formatIssue(i)));
+  lines.push(``);
+}
+
+if (backend.length > 0) {
+  lines.push(`## ⚙️ Backend`, ``);
+  backend.forEach((i) => lines.push(formatIssue(i)));
+  lines.push(``);
+}
+
+if (other.length > 0) {
+  lines.push(`## 📋 Other`, ``);
+  other.forEach((i) => lines.push(formatIssue(i)));
+  lines.push(``);
+}
+
+if (closedIssues.length > 0) {
+  lines.push(`## ✅ Closed This Week`, ``);
+  closedIssues.forEach((i) => lines.push(formatClosedIssue(i)));
+  lines.push(``);
+}
+
+lines.push(`---`);
+lines.push(
+  `[Full board on Notion](https://notion.so/319b63b6f5ec81bcbe9aeb2b6815c88c) · [GitHub Issues](https://github.com/${REPO}/issues)`
+);
+
+writeFileSync("SPRINT.md", lines.join("\n"));
+console.log(`SPRINT.md written (${lines.length} lines).`);

--- a/scripts/notion-sync.mjs
+++ b/scripts/notion-sync.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// notion-sync.mjs
+// Syncs GitHub Issues to the Notion Tasks database.
+//
+// Usage:
+//   OPERATION=create ISSUE_NUMBER=12 ISSUE_TITLE="Fix x" \
+//   AREA_LABEL=area:frontend PRIORITY_LABEL=p1 SIZE_LABEL=size:small \
+//   MILESTONE_TITLE="Sprint 1 — Bug Fix & Stability" \
+//   NOTION_API_TOKEN=secret_xxx node scripts/notion-sync.mjs
+//
+//   OPERATION=close ISSUE_NUMBER=12 \
+//   NOTION_API_TOKEN=secret_xxx node scripts/notion-sync.mjs
+
+const NOTION_TOKEN = process.env.NOTION_API_TOKEN;
+const DATABASE_ID = "872101a9165a4c8dabc02cfe03c2614b";
+const NOTION_VERSION = "2022-06-28";
+
+if (!NOTION_TOKEN) {
+  console.error("NOTION_API_TOKEN is not set.");
+  process.exit(1);
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function notionRequest(method, path, body) {
+  const res = await fetch(`https://api.notion.com/v1${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${NOTION_TOKEN}`,
+      "Notion-Version": NOTION_VERSION,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const err = await res.text();
+    throw new Error(`Notion API ${method} ${path} → ${res.status}: ${err}`);
+  }
+  return res.json();
+}
+
+// ─── Label → Notion field maps ───────────────────────────────────────────────
+
+const AREA_MAP = {
+  "area:frontend": "🎨 Frontend",
+  "area:backend": "⚙️ Backend",
+};
+
+const PRIORITY_MAP = {
+  p0: "P0 — Now",
+  p1: "P1 — Soon",
+  p2: "P2 — Later",
+  p3: "P3 — Someday",
+};
+
+const SIZE_MAP = {
+  "size:quick": "Quick",
+  "size:small": "Small",
+  "size:medium": "Medium",
+  "size:large": "Large",
+};
+
+function milestoneToStatus(milestoneTitle) {
+  if (milestoneTitle?.includes("Sprint 1")) return "Sprint 1";
+  if (milestoneTitle?.includes("Sprint 2")) return "Sprint 2";
+  return "Backlog";
+}
+
+// ─── Operations ──────────────────────────────────────────────────────────────
+
+async function createTask() {
+  const issueNumber = parseInt(process.env.ISSUE_NUMBER);
+  const issueTitle = process.env.ISSUE_TITLE;
+  const areaLabel = process.env.AREA_LABEL;
+  const priorityLabel = process.env.PRIORITY_LABEL;
+  const sizeLabel = process.env.SIZE_LABEL;
+  const milestoneTitle = process.env.MILESTONE_TITLE;
+
+  if (!issueNumber || !issueTitle) {
+    console.error("ISSUE_NUMBER and ISSUE_TITLE are required for create.");
+    process.exit(1);
+  }
+
+  // Check if a task with this Issue # already exists
+  const existing = await notionRequest(
+    "POST",
+    `/databases/${DATABASE_ID}/query`,
+    { filter: { property: "Issue #", number: { equals: issueNumber } } }
+  );
+
+  if (existing.results.length > 0) {
+    console.log(
+      `Task for Issue #${issueNumber} already exists in Notion. Skipping.`
+    );
+    return;
+  }
+
+  const properties = {
+    Task: { title: [{ text: { content: issueTitle } }] },
+    "Issue #": { number: issueNumber },
+  };
+
+  if (areaLabel && AREA_MAP[areaLabel]) {
+    properties.Area = { select: { name: AREA_MAP[areaLabel] } };
+    properties.Sprint = {
+      select: {
+        name: milestoneTitle ?? "Sprint 1 — Bug Fix & Stability",
+      },
+    };
+    properties.Status = {
+      select: { name: milestoneToStatus(milestoneTitle) },
+    };
+  }
+  if (priorityLabel && PRIORITY_MAP[priorityLabel]) {
+    properties.Priority = { select: { name: PRIORITY_MAP[priorityLabel] } };
+  }
+  if (sizeLabel && SIZE_MAP[sizeLabel]) {
+    properties.Size = { select: { name: SIZE_MAP[sizeLabel] } };
+  }
+
+  const page = await notionRequest("POST", "/pages", {
+    parent: { database_id: DATABASE_ID },
+    properties,
+  });
+
+  console.log(
+    `Created Notion task: "${issueTitle}" (Issue #${issueNumber}) → ${page.url}`
+  );
+}
+
+async function closeTask() {
+  const issueNumber = parseInt(process.env.ISSUE_NUMBER);
+  if (!issueNumber) {
+    console.error("ISSUE_NUMBER is required for close.");
+    process.exit(1);
+  }
+
+  const result = await notionRequest(
+    "POST",
+    `/databases/${DATABASE_ID}/query`,
+    { filter: { property: "Issue #", number: { equals: issueNumber } } }
+  );
+
+  if (result.results.length === 0) {
+    console.log(
+      `No Notion task found for Issue #${issueNumber}. Nothing to close.`
+    );
+    return;
+  }
+
+  const pageId = result.results[0].id;
+  await notionRequest("PATCH", `/pages/${pageId}`, {
+    properties: { Status: { select: { name: "Done" } } },
+  });
+
+  console.log(`Notion task for Issue #${issueNumber} → Done.`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const operation = process.env.OPERATION;
+if (operation === "create") {
+  await createTask();
+} else if (operation === "close") {
+  await closeTask();
+} else {
+  console.error(`Unknown OPERATION: "${operation}". Use "create" or "close".`);
+  process.exit(1);
+}

--- a/scripts/setup-github.sh
+++ b/scripts/setup-github.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# setup-github.sh
+# One-time setup: creates labels, milestones, and Sprint 1 issues.
+# Safe to re-run — gh label/milestone create is idempotent via --force.
+#
+# Usage: bash scripts/setup-github.sh
+
+set -e
+
+REPO="s0lci700/OVERLAYS"
+
+echo "▶ Verifying gh authentication..."
+gh auth status
+
+echo ""
+echo "▶ Creating labels..."
+
+# Area labels
+gh label create "area:frontend" --color "0075ca" --description "Svelte components, CSS, overlays" --repo "$REPO" --force
+gh label create "area:backend"  --color "5319e7" --description "server.js, API routes, Socket.io, PocketBase" --repo "$REPO" --force
+
+# Priority labels
+gh label create "p0" --color "d73a4a" --description "Blocking — fix now"        --repo "$REPO" --force
+gh label create "p1" --color "e4e669" --description "Important — this sprint"    --repo "$REPO" --force
+gh label create "p2" --color "0e8a16" --description "Nice to have — next sprint" --repo "$REPO" --force
+gh label create "p3" --color "cccccc" --description "Someday / maybe"            --repo "$REPO" --force
+
+# Size labels
+gh label create "size:quick"  --color "c2e0c6" --description "< 1 hour"   --repo "$REPO" --force
+gh label create "size:small"  --color "bfd4f2" --description "1–3 hours"  --repo "$REPO" --force
+gh label create "size:medium" --color "fef2c0" --description "3–8 hours"  --repo "$REPO" --force
+gh label create "size:large"  --color "f9d0c4" --description "8+ hours"   --repo "$REPO" --force
+
+echo "✓ Labels created."
+
+echo ""
+echo "▶ Creating milestones..."
+
+gh api "repos/$REPO/milestones" -X POST \
+  -f title="Sprint 1 — Bug Fix & Stability" \
+  -f description="Demo-ready stability. Fix bugs, accessibility polish, E2E smoke test." \
+  -f due_on="2026-03-18T23:59:59Z" 2>/dev/null || echo "  (Sprint 1 already exists)"
+
+gh api "repos/$REPO/milestones" -X POST \
+  -f title="Sprint 2 — PocketBase & Persistence" \
+  -f description="Migrate from in-memory to PocketBase. Survive server restarts." 2>/dev/null || echo "  (Sprint 2 already exists)"
+
+gh api "repos/$REPO/milestones" -X POST \
+  -f title="Sprint 3 — DM Panel & Effects" \
+  -f description="DM Session Panel, initiative tracker, sound effects, live theme editor." 2>/dev/null || echo "  (Sprint 3 already exists)"
+
+echo "✓ Milestones created."
+
+# Get Sprint 1 milestone number
+MILESTONE=$(gh api "repos/$REPO/milestones" --jq '.[] | select(.title | contains("Sprint 1")) | .number')
+echo "  Sprint 1 milestone number: $MILESTONE"
+
+echo ""
+echo "▶ Creating Sprint 1 issues..."
+
+# P0 — Fix now
+gh issue create --repo "$REPO" \
+  --title "Fix Spanish diacriticals" \
+  --body "Overlay text renders incorrectly for accented chars (ó, é, ñ, etc.). Check character name rendering across overlay components." \
+  --label "area:frontend,p0,size:quick" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "Fix cyan mismatch in level pills" \
+  --body "Level pill colour doesn't match the ESDH brand cyan (#00D4FF). Update tokens and verify in HP overlay." \
+  --label "area:frontend,p0,size:quick" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+# P1 — This sprint
+gh issue create --repo "$REPO" \
+  --title "Add loading state on API calls" \
+  --body "updateHp() and rollDice() don't disable buttons during fetch. Add \`let loading = \$state(false)\` and \`disabled={loading}\` in CharacterCard.svelte and DiceRoller.svelte." \
+  --label "area:backend,p1,size:small" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "d20 button full-width fix" \
+  --body "d20 button should span full width in the dice grid. Fix: \`grid-column: 1 / -1\` in .dice-grid in DiceRoller.css." \
+  --label "area:frontend,p1,size:quick" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "Fix role=tablist in PhotoSourcePicker" \
+  --body "Segment control buttons missing role=tab, aria-selected, aria-controls. Screen readers announce 0 tabs. Fix in PhotoSourcePicker.svelte." \
+  --label "area:frontend,p1,size:small" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "Modal focus trap — replace dialog open with showModal()" \
+  --body "Modals use <dialog open> which doesn't trap focus or handle Escape. Replace with showModal() for proper native dialog behaviour." \
+  --label "area:frontend,p1,size:small" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "Sidebar navigation → SvelteKit goto()" \
+  --body "window.location.pathname causes full page reload. Replace with goto() from \$app/navigation in +layout.svelte sidebar links." \
+  --label "area:frontend,p1,size:small" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "E2E smoke test — full demo script run-through" \
+  --body "Before Sprint 1 is done: open phone → update character HP → roll d20 → trigger crit → apply condition → verify OBS overlays update. Document results." \
+  --label "area:backend,p1,size:small" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+# P2 — Next sprint
+gh issue create --repo "$REPO" \
+  --title "Standardize anime.js import path" \
+  --body "anime.js import path is inconsistent across overlay components. Standardize to a single import in all overlay files." \
+  --label "area:frontend,p2,size:quick" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+gh issue create --repo "$REPO" \
+  --title "Rename .char-card.collapsed to .is-collapsed" \
+  --body "CSS class naming convention: .char-card.collapsed should follow BEM-ish convention as .char-card.is-collapsed. Update CharacterCard.svelte and CharacterCard.css." \
+  --label "area:frontend,p2,size:quick" \
+  --milestone "$MILESTONE" 2>/dev/null || echo "  (already exists)"
+
+echo ""
+echo "✓ Sprint 1 issues created."
+echo ""
+echo "▶ Verifying..."
+gh issue list --repo "$REPO" --milestone "Sprint 1 — Bug Fix & Stability"
+echo ""
+echo "✅ Setup complete. Notion sync will activate once NOTION_API_TOKEN secret is set."


### PR DESCRIPTION
## What this does

Connects GitHub Issues to Notion board and adds SPRINT.md auto-generation.

### New files
- \scripts/generate-sprint.mjs\ — generates \SPRINT.md\ grouped by 🎨 Frontend / ⚙️ Backend from active milestone
- \scripts/notion-sync.mjs\ — creates Notion task when area label applied; marks Done when issue closed
- \scripts/setup-github.sh\ — **one-time setup**: creates 10 labels, 3 milestones, Sprint 1 issues
- \.github/workflows/sprint-file.yml\ — regenerates SPRINT.md on any issue event (\[skip ci]\)
- \.github/workflows/issue-sync.yml\ — calls notion-sync.mjs on \labeled\ + \closed\ events

### Updated docs
- \CLAUDE.md\ — appended Agent Rules: when to file GitHub Issues vs Notion tasks
- \.github/copilot-instructions.md\ — **fully rewritten**: now reflects bun + PocketBase + SvelteKit \(stage)/\ routes (was describing old npm/node/vanilla-HTML architecture)

## One-time user actions required
1. Run \ash scripts/setup-github.sh\ after merging to create labels + milestones + Sprint 1 issues
2. Create a Notion integration at https://www.notion.so/my-integrations
3. Share the Tasks DB with that integration (Connections panel)
4. Add \NOTION_API_TOKEN\ secret to this repo (different from existing \NOTION_TOKEN\)